### PR TITLE
docs: update client docs for v0.9.2 website credentials login

### DIFF
--- a/docs/pages/client/afterInstall.md
+++ b/docs/pages/client/afterInstall.md
@@ -68,7 +68,7 @@ When a new docker image is deployed with an empty `/config` folder mounted, the 
 - Write a brand new config to `/config/notifiarr.conf` file.
 - On first run, the WebUI will prompt you for your API key.
 - After entering your API key, login with your **Notifiarr.com email address and password**.
-- You can set a local password after logging in via *Config → Password*.
+- You can set a local password after logging in via *Trust Profile* (click your username in the top right).
 
 Environment Variables - and the Unraid Template - override settings in the Config file.
 

--- a/docs/pages/client/afterInstall.md
+++ b/docs/pages/client/afterInstall.md
@@ -26,9 +26,9 @@ key in the config file @ `/etc/notifiarr/notifiarr.conf` or
 `/usr/local/etc/notifiarr/notifiarr.conf`. If you installed on a seed box, set
 the API key in the config file in your home folder.
 
-Most users will use the API key as the password to login into the client's WebUI for
-the first time. You can set a dedicated password after logging in by clicking your
-*username in the menu => Trust Profile*. **The default username is `admin`**.
+Login to the client's WebUI for the first time with your **Notifiarr.com email address and password**.
+You can set a dedicated local password after logging in by clicking your
+*username in the menu => Trust Profile*.
 
 The login URL will usually look like one of these. The default listen port is `5454`.
 
@@ -63,11 +63,12 @@ volumes:
 
 ## Docker Users
 
-When a new docker image is deployed with an empty `/config` folder mounted, the app will do two things:
+When a new docker image is deployed with an empty `/config` folder mounted, the app will:
 
-- *If the API Key is not configured or invalid:* Create a new Web UI `admin` **password** and print it into the log file and docker logs.
-- Write a brand new config to `/config/notifiarr.conf` file with this password already saved.
-- Find the password by running `docker logs Notifiarr`.
+- Write a brand new config to `/config/notifiarr.conf` file.
+- On first run, the WebUI will prompt you for your API key.
+- After entering your API key, login with your **Notifiarr.com email address and password**.
+- You can set a local password after logging in via *Config → Password*.
 
 Environment Variables - and the Unraid Template - override settings in the Config file.
 

--- a/docs/pages/client/afterInstall.md
+++ b/docs/pages/client/afterInstall.md
@@ -68,7 +68,7 @@ When a new docker image is deployed with an empty `/config` folder mounted, the 
 - Write a brand new config to `/config/notifiarr.conf` file.
 - On first run, the WebUI will prompt you for your API key.
 - After entering your API key, login with your **Notifiarr.com email address and password**.
-- You can set a local password after logging in via *Trust Profile* (click your username in the top right).
+- You can set a local password after logging in *Trust Profile* by clicking your username in the bottom left.
 
 Environment Variables - and the Unraid Template - override settings in the Config file.
 

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -74,13 +74,13 @@ service notifiarr start
 ## Windows
 
 !!! info
-Suggested location and structure based on experience with permissions.
+    Suggested location and structure based on experience with permissions.
 
 ### Desired Outcome
 
-    - `C:\ProgramData\notifiarr\notifiarr.amd64.exe` - The Application.
-    - `C:\ProgramData\notifiarr\notifiarr.conf` - The config file. Just the add the API key.
-    - `C:\ProgramData\notifiarr\logs` - Folder for log files.
+- `C:\ProgramData\notifiarr\notifiarr.amd64.exe` - The Application.
+- `C:\ProgramData\notifiarr\notifiarr.conf` - The config file. Just the add the API key.
+- `C:\ProgramData\notifiarr\logs` - Folder for log files.
 
 ### Create the folders
 
@@ -326,4 +326,5 @@ curl -sSL https://raw.githubusercontent.com/Notifiarr/notifiarr/main/userscripts
 
     1. Type `systemctl --user restart nginx`
     1. Now you should be able to browse to `https://your-ultraseedbox-url/notifiarr`
+
 

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -87,9 +87,9 @@ service notifiarr start
 1. Open C:\ProgramData and create a folder `notifiarr`
 1. Create a new folder named `logs`, so you now have `C:\ProgramData\notifiarr\logs`
     - When you add the log paths in the client UI (later steps), make sure you point them to a file such as:
-        - `C:\ProgramData\notifiarr\logs\app.log`
-        - `C:\ProgramData\notifiarr\logs\debug.log`
-        - `C:\ProgramData\notifiarr\logs\http.log`
+      - `C:\ProgramData\notifiarr\logs\app.log`
+      - `C:\ProgramData\notifiarr\logs\debug.log`
+      - `C:\ProgramData\notifiarr\logs\http.log`
 
 ### New Install
 
@@ -326,3 +326,4 @@ curl -sSL https://raw.githubusercontent.com/Notifiarr/notifiarr/main/userscripts
 
     1. Type `systemctl --user restart nginx`
     1. Now you should be able to browse to `https://your-ultraseedbox-url/notifiarr`
+

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -71,45 +71,67 @@ service notifiarr start
 1. Use the menu bar icon to access the WebUI.
 1. Head on over to [After Install](afterInstall.md).
 
-## Windows Installation
+## Windows
 
-### Directory Structure
+!!! info
+Suggested location and structure based on experience with permissions.
 
-Create the following in 
+### Desired Outcome
 
-`C:\ProgramData\notifiarr\`:
+- `C:\ProgramData\notifiarr\notifiarr.amd64.exe` - The Application.
+- `C:\ProgramData\notifiarr\notifiarr.conf` - The config file. Just the add the API key.
+- `C:\ProgramData\notifiarr\logs` - Folder for log files.
 
-```none
-notifiarr.amd64.exe
-notifiarr.conf
-logs\
-```
+### Create the folders
+
+1. Open C:\ProgramData and create a folder `notifiarr`
+1. Create a new folder named `logs`, so you now have `C:\ProgramData\notifiarr\logs`
+- When you add the log paths in the client UI (later steps), make sure you point them to a file such as:
+  - `C:\ProgramData\notifiarr\logs\app.log`
+  - `C:\ProgramData\notifiarr\logs\debug.log`
+  - `C:\ProgramData\notifiarr\logs\http.log`
 
 ### New Install
 
-1. Download `notifiarr.amd64.exe.zip` from the [Releases page](https://github.com/Notifiarr/notifiarr/releases)
-1. Extract to `C:\ProgramData\notifiarr\`
-1. Move the `.exe` and `.conf.example` files to the root of that folder
+1. Download `notifiarr.amd64.exe.zip` from [the Releases page](https://github.com/Notifiarr/notifiarr/releases)
+1. Save it in `C:\ProgramData\notifiarr`
+1. Open the folder that was created from extracting and copy the `.exe` + example `.conf` files up one directory so it is located at:
+- `C:\ProgramData\notifiarr\notifiarr.amd64.exe`
+- `C:\ProgramData\notifiarr\notifiarr.conf.example`
+1. You can now delete the `.zip` file that was downloaded and the folder that was extracted
 1. Rename `notifiarr.conf.example` to `notifiarr.conf`
-1. Delete the downloaded `.zip` and extracted folder
+1. Double-click `notifiarr.amd64.exe` to launch
+1. Enter your API key when prompted
 
-### Migrating Existing Install
+### Fix Existing Install
 
 1. Stop the client
-1. Copy your existing `.exe` and `.conf` to `C:\ProgramData\notifiarr\`
-1. Delete `C:\Users\<username>\.notifiarr` if it exists
+1. Copy the existing `.exe` to `C:\ProgramData\notifiarr\notifiarr.amd64.exe`
+1. Copy the existing conf file to `C:\ProgramData\notifiarr\notifiarr.conf`
+1. If the `C:\users\<your home folder>\.notifiarr` folder exists, delete it
 
 ### First Run & Autostart
 
-1. Double-click the `.exe` to launch
+- At this point, the structure should look like the [Desired Outcome mentioned above](#desired-outcome).
+
+#### First Run
+
+1. Double-click `notifiarr.amd64.exe` to launch
 1. Enter your API key when prompted
-1. Access the Web UI at `127.0.0.1:5454` using `admin` as the username and your API key as the password
+1. Access the Web UI at `localhost:5454`
+- Username: `admin`
+- Password: Your API key
 
-To enable autostart:
+#### Autostart
 
-1. Right-click the `.exe` and create a shortcut
-1. Press `Win+R`, type `shell:startup`, press Enter
-1. Move the shortcut to the opened Startup folder
+1. Right-click on the `.exe` and create a shortcut
+1. Press Windows key + R, type `shell:startup`, then select OK
+1. Copy the shortcut to the opened Startup folder
+
+#### Finding Password in Logs (if needed)
+
+- **Option A:** Check `notifiarr.log` (or `app.log`) - password is at the top of the file
+- **Option B:** Right-click the notifiarr tray icon → Logs → View
 
 ## Synology
 
@@ -304,5 +326,6 @@ curl -sSL https://raw.githubusercontent.com/Notifiarr/notifiarr/main/userscripts
 
     1. Type `systemctl --user restart nginx`
     1. Now you should be able to browse to `https://your-ultraseedbox-url/notifiarr`
+
 
 

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -102,6 +102,7 @@ service notifiarr start
 1. Rename `notifiarr.conf.example` to `notifiarr.conf`
 1. Double-click `notifiarr.amd64.exe` to launch the client. The webui will be available at [http://127.0.0.1:5454](http://127.0.0.1:5454)
 1. Enter your API key when prompted
+1. Login for the first time with your Notifiarr.com email address and password.
 
 ### Fix Existing Install
 
@@ -119,8 +120,9 @@ service notifiarr start
 1. Double-click `notifiarr.amd64.exe` to launch
 1. Enter your API key when prompted
 1. Access the Web UI at [http://127.0.0.1:5454](http://127.0.0.1:5454)
-- Username: `admin`
-- Password: Your API key
+    - Username: email address you login to notifiarr.com with
+    - Password: password for notifiarr.com
+1. You may set a local password after you login.
 
 #### Autostart
 
@@ -128,10 +130,10 @@ service notifiarr start
 1. Press Windows key + R, type `shell:startup`, then select OK
 1. Copy the shortcut to the opened Startup folder
 
-#### Finding Password in Logs (if needed)
+#### Setting a Local Password
 
-- **Option A:** Check `notifiarr.log` (or `app.log`) - password is at the top of the file
-- **Option B:** Right-click the notifiarr tray icon → Logs → View
+- **Option A:** In the Web UI, go to Config → Password
+- **Option B:** Right-click the notifiarr tray icon → Config → Password - and set a new password.
 
 ## Synology
 

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -66,8 +66,8 @@ service notifiarr start
 1. Download the signed `dmg` file from the [Releases](https://github.com/Notifiarr/notifiarr/releases) page.
 1. Mount it and copy *Notifiarr.app* to */Applications* then double-click it there.
 1. When you open it for the first time it will create a config file and log file:
-    1. `~/.notifiarr/notifiarr.conf`
-    1. `~/.notifiarr/Notifiarr.log`
+    - `~/.notifiarr/notifiarr.conf`
+    - `~/.notifiarr/Notifiarr.log`
 1. Use the menu bar icon to access the WebUI.
 1. Head on over to [After Install](afterInstall.md).
 
@@ -78,9 +78,9 @@ Suggested location and structure based on experience with permissions.
 
 ### Desired Outcome
 
-- `C:\ProgramData\notifiarr\notifiarr.amd64.exe` - The Application.
-- `C:\ProgramData\notifiarr\notifiarr.conf` - The config file. Just the add the API key.
-- `C:\ProgramData\notifiarr\logs` - Folder for log files.
+    - `C:\ProgramData\notifiarr\notifiarr.amd64.exe` - The Application.
+    - `C:\ProgramData\notifiarr\notifiarr.conf` - The config file. Just the add the API key.
+    - `C:\ProgramData\notifiarr\logs` - Folder for log files.
 
 ### Create the folders
 
@@ -96,8 +96,8 @@ Suggested location and structure based on experience with permissions.
 1. Download `notifiarr.amd64.exe.zip` from [the Releases page](https://github.com/Notifiarr/notifiarr/releases)
 1. Save it in `C:\ProgramData\notifiarr`
 1. Open the folder that was created from extracting and copy the `.exe` + example `.conf` files up one directory so it is located at:
-- `C:\ProgramData\notifiarr\notifiarr.amd64.exe`
-- `C:\ProgramData\notifiarr\notifiarr.conf.example`
+    - `C:\ProgramData\notifiarr\notifiarr.amd64.exe`
+    - `C:\ProgramData\notifiarr\notifiarr.conf.example`
 1. You can now delete the `.zip` file that was downloaded and the folder that was extracted
 1. Rename `notifiarr.conf.example` to `notifiarr.conf`
 1. Double-click `notifiarr.amd64.exe` to launch the client. The webui will be available at [http://127.0.0.1:5454](http://127.0.0.1:5454)
@@ -326,3 +326,4 @@ curl -sSL https://raw.githubusercontent.com/Notifiarr/notifiarr/main/userscripts
 
     1. Type `systemctl --user restart nginx`
     1. Now you should be able to browse to `https://your-ultraseedbox-url/notifiarr`
+

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -111,11 +111,9 @@ service notifiarr start
 1. Copy the existing conf file to `C:\ProgramData\notifiarr\notifiarr.conf`
 1. If the `C:\users\<your home folder>\.notifiarr` folder exists, delete it
 
-### First Run & Autostart
-
 - At this point, the structure should look like the [Desired Outcome mentioned above](#desired-outcome).
 
-#### First Run
+### First Run
 
 1. Double-click `notifiarr.amd64.exe` to launch
 1. Enter your API key when prompted
@@ -124,15 +122,15 @@ service notifiarr start
     - Password: password for notifiarr.com
 1. You may set a local password after you login.
 
-#### Autostart
+### Autostart
 
 1. Right-click on `notifiarr.amd64.exe` and create a shortcut.
 1. Press Windows key + R, type `shell:startup`, then select OK
 1. Copy the shortcut to the opened Startup folder
 
-#### Setting a Local Password
+### Setting a Local Password
 
-- **Option A:** In the Web UI, go to Config → Password
+- **Option A:** In the Web UI, click your username → Trust Profile
 - **Option B:** Right-click the notifiarr tray icon → Config → Password - and set a new password.
 
 ## Synology

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -100,7 +100,7 @@ Suggested location and structure based on experience with permissions.
 - `C:\ProgramData\notifiarr\notifiarr.conf.example`
 1. You can now delete the `.zip` file that was downloaded and the folder that was extracted
 1. Rename `notifiarr.conf.example` to `notifiarr.conf`
-1. Double-click `notifiarr.amd64.exe` to launch the client. The webui will be available at `http://127.0.0.1:5454`
+1. Double-click `notifiarr.amd64.exe` to launch the client. The webui will be available at [http://127.0.0.1:5454](http://127.0.0.1:5454)
 1. Enter your API key when prompted
 
 ### Fix Existing Install

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -124,7 +124,7 @@ Suggested location and structure based on experience with permissions.
 
 #### Autostart
 
-1. Right-click on the `.exe` and create a shortcut
+1. Right-click on `notifiarr.amd64.exe` and create a shortcut.
 1. Press Windows key + R, type `shell:startup`, then select OK
 1. Copy the shortcut to the opened Startup folder
 

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -71,9 +71,9 @@ service notifiarr start
 1. Use the menu bar icon to access the WebUI.
 1. Head on over to [After Install](afterInstall.md).
 
-# Windows Installation
+## Windows Installation
 
-## Directory Structure
+### Directory Structure
 
 Create the following in 
 
@@ -85,7 +85,7 @@ notifiarr.conf
 logs\
 ```
 
-## New Install
+### New Install
 
 1. Download `notifiarr.amd64.exe.zip` from the [Releases page](https://github.com/Notifiarr/notifiarr/releases)
 1. Extract to `C:\ProgramData\notifiarr\`
@@ -93,17 +93,17 @@ logs\
 1. Rename `notifiarr.conf.example` to `notifiarr.conf`
 1. Delete the downloaded `.zip` and extracted folder
 
-## Migrating Existing Install
+### Migrating Existing Install
 
 1. Stop the client
 1. Copy your existing `.exe` and `.conf` to `C:\ProgramData\notifiarr\`
 1. Delete `C:\Users\<username>\.notifiarr` if it exists
 
-## First Run & Autostart
+### First Run & Autostart
 
 1. Double-click the `.exe` to launch
 1. Enter your API key when prompted
-1. Access the Web UI at `localhost:5454` using `admin` as the username and your API key as the password
+1. Access the Web UI at `127.0.0.1:5454` using `admin` as the username and your API key as the password
 
 To enable autostart:
 
@@ -304,4 +304,5 @@ curl -sSL https://raw.githubusercontent.com/Notifiarr/notifiarr/main/userscripts
 
     1. Type `systemctl --user restart nginx`
     1. Now you should be able to browse to `https://your-ultraseedbox-url/notifiarr`
+
 

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -86,10 +86,10 @@ service notifiarr start
 
 1. Open C:\ProgramData and create a folder `notifiarr`
 1. Create a new folder named `logs`, so you now have `C:\ProgramData\notifiarr\logs`
-- When you add the log paths in the client UI (later steps), make sure you point them to a file such as:
-  - `C:\ProgramData\notifiarr\logs\app.log`
-  - `C:\ProgramData\notifiarr\logs\debug.log`
-  - `C:\ProgramData\notifiarr\logs\http.log`
+    - When you add the log paths in the client UI (later steps), make sure you point them to a file such as:
+        - `C:\ProgramData\notifiarr\logs\app.log`
+        - `C:\ProgramData\notifiarr\logs\debug.log`
+        - `C:\ProgramData\notifiarr\logs\http.log`
 
 ### New Install
 
@@ -326,5 +326,3 @@ curl -sSL https://raw.githubusercontent.com/Notifiarr/notifiarr/main/userscripts
 
     1. Type `systemctl --user restart nginx`
     1. Now you should be able to browse to `https://your-ultraseedbox-url/notifiarr`
-
-

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -100,7 +100,7 @@ Suggested location and structure based on experience with permissions.
 - `C:\ProgramData\notifiarr\notifiarr.conf.example`
 1. You can now delete the `.zip` file that was downloaded and the folder that was extracted
 1. Rename `notifiarr.conf.example` to `notifiarr.conf`
-1. Double-click `notifiarr.amd64.exe` to launch
+1. Double-click `notifiarr.amd64.exe` to launch the client. The webui will be available at `http://127.0.0.1:5454`
 1. Enter your API key when prompted
 
 ### Fix Existing Install
@@ -118,7 +118,7 @@ Suggested location and structure based on experience with permissions.
 
 1. Double-click `notifiarr.amd64.exe` to launch
 1. Enter your API key when prompted
-1. Access the Web UI at `localhost:5454`
+1. Access the Web UI at `http://127.0.0.1:5454`
 - Username: `admin`
 - Password: Your API key
 
@@ -326,6 +326,3 @@ curl -sSL https://raw.githubusercontent.com/Notifiarr/notifiarr/main/userscripts
 
     1. Type `systemctl --user restart nginx`
     1. Now you should be able to browse to `https://your-ultraseedbox-url/notifiarr`
-
-
-

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -71,54 +71,45 @@ service notifiarr start
 1. Use the menu bar icon to access the WebUI.
 1. Head on over to [After Install](afterInstall.md).
 
-## Windows
+# Windows Installation
 
-!!! info
-    Suggested location and structure based on experience with permissions.
+## Directory Structure
 
-### Desired Outcome
+Create the following in 
 
-- `C:\ProgramData\notifiarr\notifiarr.amd64.exe` - The Application.
-- `C:\ProgramData\notifiarr\notifiarr.conf` - The config file. Just the add the API key.
-- `C:\ProgramData\notifiarr\logs` - Folder for log files.
+`C:\ProgramData\notifiarr\`:
 
-### Create the folders
+```none
+notifiarr.amd64.exe
+notifiarr.conf
+logs\
+```
 
-1. Open C:\ProgramData and create a folder `notifiarr`
-1. Create a new folder named `logs`, so you now have `C:\ProgramData\notifiarr\logs`
-    - When you add the log paths in the client UI (later steps), make sure you point them to a file such as:
-      - `C:\ProgramData\notifiarr\logs\app.log`
-      - `C:\ProgramData\notifiarr\logs\debug.log`
-      - `C:\ProgramData\notifiarr\logs\http.log`
+## New Install
 
-### New Install
-
-1. Download `notifiarr.amd64.exe.zip` from [the Releases page](https://github.com/Notifiarr/notifiarr/releases)
-1. Save it in `C:\ProgramData\notifiarr`
-1. Open the folder that was created from extracting and copy the `.exe` + example `.conf` files up one directory so it is located at:
-    - `C:\ProgramData\notifiarr\notifiarr.amd64.exe`
-    - `C:\ProgramData\notifiarr\notifiarr.conf.example`
-1. You can now delete the `.zip` file that was downloaded and the folder that was extracted
+1. Download `notifiarr.amd64.exe.zip` from the [Releases page](https://github.com/Notifiarr/notifiarr/releases)
+1. Extract to `C:\ProgramData\notifiarr\`
+1. Move the `.exe` and `.conf.example` files to the root of that folder
 1. Rename `notifiarr.conf.example` to `notifiarr.conf`
+1. Delete the downloaded `.zip` and extracted folder
 
-### Fix Existing Install
+## Migrating Existing Install
 
 1. Stop the client
-1. Copy the existing `.exe` to `C:\ProgramData\notifiarr\notifiarr.amd64.exe`
-1. Copy the existing conf file to `C:\ProgramData\notifiarr\notifiarr.conf`
-1. If the `C:\users\<your home folder>\.notifiarr` folder exists, delete it
+1. Copy your existing `.exe` and `.conf` to `C:\ProgramData\notifiarr\`
+1. Delete `C:\Users\<username>\.notifiarr` if it exists
 
-### Autostart & Password
+## First Run & Autostart
 
-- At this point, the structure should look like the [Desired Outcome mentioned above](#desired-outcome).
+1. Double-click the `.exe` to launch
+1. Enter your API key when prompted
+1. Access the Web UI at `localhost:5454` using `admin` as the username and your API key as the password
 
-1. Right click on the `.exe` and create a shortcut
-1. Windows logo key + R, type `shell:startup`, then select OK. This opens the Startup folder.
-1. Copy and paste the newly created shortcut from its current location to the opened Startup folder.
-1. Double click on the shortcut and the client is now running
-1. If this is the first time you have ran it:
-    1. Option A: Look at the notifiarr.log (or app.log) and you will see the password at the top of the file.
-    1. Option B: Right click on the notifiarr icon and pick Logs -> View and get the login credentials from there.
+To enable autostart:
+
+1. Right-click the `.exe` and create a shortcut
+1. Press `Win+R`, type `shell:startup`, press Enter
+1. Move the shortcut to the opened Startup folder
 
 ## Synology
 
@@ -313,3 +304,4 @@ curl -sSL https://raw.githubusercontent.com/Notifiarr/notifiarr/main/userscripts
 
     1. Type `systemctl --user restart nginx`
     1. Now you should be able to browse to `https://your-ultraseedbox-url/notifiarr`
+

--- a/docs/pages/client/install.md
+++ b/docs/pages/client/install.md
@@ -118,7 +118,7 @@ Suggested location and structure based on experience with permissions.
 
 1. Double-click `notifiarr.amd64.exe` to launch
 1. Enter your API key when prompted
-1. Access the Web UI at `http://127.0.0.1:5454`
+1. Access the Web UI at [http://127.0.0.1:5454](http://127.0.0.1:5454)
 - Username: `admin`
 - Password: Your API key
 

--- a/docs/pages/client/troubleshooting.md
+++ b/docs/pages/client/troubleshooting.md
@@ -87,10 +87,7 @@ docker exec Notifiarr /notifiarr --reset
 docker kill --signal=HUP Notifiarr
 ```
 
-```bash
-# Example output with new password:
-[INFO] 2023/09/08 09:32:11 New 'admin' user password: four38=Draw
-[INFO] 2023/09/08 09:32:11 Writing Config File: /config/notifiarr.conf
-```
+!!! note "About Reset"
+    The `--reset` command creates a local admin password as a recovery fallback. This is only needed if you can't login with your Notifiarr.com credentials. After reset, you can login with username `admin` and the generated password, then set up your normal authentication.
 
 - If you still can't login, restart the container.


### PR DESCRIPTION
## Summary

Updates client documentation to reflect v0.9.2 changes: **login with website credentials by default**.

### Changes

**install.md (Windows section):**
- Add login step with Notifiarr.com credentials after API key entry
- Fix username/password to use Notifiarr.com email/password (not admin/API key)
- Add note about setting local password after login
- Replace 'Finding Password in Logs' with 'Setting a Local Password' section
- Update password methods to use Config → Password

**afterInstall.md:**
- Login now uses Notifiarr.com email/password
- Clarify Docker first-run prompts for API key then credentials
- Update Trust Profile reference for setting local password

**troubleshooting.md:**
- Clarify that `--reset` creates a local admin password as a **recovery fallback**
- This is only needed when you can't login with website credentials

### Reference

- v0.9.2 release: "Login to client with website credentials by default"
- PR #1139: Allow logging in with website credentials
- Code: `pkg/client/handlers_gui.go:170-180` - `clientinfo.CheckPassword()`