### PR TITLE
Update Apprise documentation with official link

### DIFF
--- a/docs/pages/integrations/apprise.md
+++ b/docs/pages/integrations/apprise.md
@@ -26,7 +26,7 @@ notifiarr://{api_key}/{channel1_id}/{channel2_id}/{channelN_id}
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `api_key` | Yes | Your **global** Notifiarr API key (integration-specific keys will not work) |
+| `api_key` | Yes | Your Notifiarr API key — either a global key or an integration-specific key. An **Apprise integration key** generated on your [Notifiarr profile page](https://notifiarr.com) is recommended. |
 | `channel_id` | Yes | Numeric Discord channel ID (enable Developer Mode in Discord to find this) |
 
 ---

--- a/docs/pages/integrations/apprise.md
+++ b/docs/pages/integrations/apprise.md
@@ -1,3 +1,5 @@
 # Apprise
 
-COMING SOON :smile:
+Please see [Apprise's Documentation at aprriseit.com](https://appriseit.com/services/notifiarr/).
+
+Notifiarr Documentation coming soon

--- a/docs/pages/integrations/apprise.md
+++ b/docs/pages/integrations/apprise.md
@@ -1,5 +1,42 @@
 # Apprise
 
-Please see [Apprise's Documentation at aprriseit.com](https://appriseit.com/services/notifiarr/).
+!!! info
+    [Apprise](https://github.com/caronc/apprise) allows you to send notifications from Notifiarr to hundreds of notification services. This page covers how Apprise connects to Notifiarr — for the full list of Apprise notification services, see [appriseit.com](https://appriseit.com/).
 
-Notifiarr Documentation coming soon
+---
+
+## How It Works
+
+Apprise can send notifications **to** Notifiarr using the Notifiarr notification service plugin. This lets you route alerts from any Apprise-compatible source into your Notifiarr Discord channels.
+
+For full setup instructions, see [Apprise's Notifiarr documentation](https://appriseit.com/services/notifiarr/).
+
+---
+
+## URL Format
+
+```text
+notifiarr://{api_key}/{channel_id}
+notifiarr://{api_key}/{channel1_id}/{channel2_id}/{channelN_id}
+```
+
+---
+
+## Requirements
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `api_key` | Yes | Your **global** Notifiarr API key (integration-specific keys will not work) |
+| `channel_id` | Yes | Numeric Discord channel ID (enable Developer Mode in Discord to find this) |
+
+---
+
+## Optional Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `source` / `from` | Label describing the notification origin |
+| `event` | Existing event ID to update instead of creating a new notification |
+
+!!! warning
+    As of this writing, the upstream Apprise webhook to Notifiarr only supports one user/role mention per payload.


### PR DESCRIPTION
Updated Apprise documentation to include a link to official documentation and removed placeholder text.