### PR TITLE
feat: MkDocs config improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
             ${{ runner.os }}-pip-
       - run: |
           python3 -m pip install -r requirements.txt
-          mkdocs build
+          mkdocs build --strict

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         run: python3 -m pip install -r ./requirements.txt
 
       - name: Build Docs
-        run: mkdocs build
+        run: mkdocs build --strict
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv
+site/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,9 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
   - tables
   - pymdownx.tabbed:
       alternate_style: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,8 @@ theme:
     - navigation.top
     - navigation.tracking
     - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.instant.progress
     - toc.follow
     - search.suggest
     - search.highlight

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ extra_css:
   - stylesheets/github-permalink-style.css
 
 plugins:
+  - search
   - glightbox:
       touchNavigation: true
       loop: false
@@ -142,7 +143,12 @@ plugins:
       draggable: true
       auto_caption: false
       caption_position: bottom
-  - search
+  - minify:
+      minify_html: true
+      minify_js: true
+      minify_css: true
+      htmlmin_opts:
+        remove_comments: true
 
 markdown_extensions:
   - attr_list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,4 +161,4 @@ markdown_extensions:
   - md_in_html
   - toc:
       toc_depth: 4
-      permalink: ''
+      permalink: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs~=1.6.0
 mkdocs-material~=9.7.1
 mkdocs-material-extensions~=1.3.0
 mkdocs-glightbox~=0.5.0
+mkdocs-minify-plugin~=0.8.0


### PR DESCRIPTION
## Summary

- Add `navigation.instant.prefetch` and `navigation.instant.progress` for faster perceived navigation
- Add `pymdownx.highlight` (with anchor line numbers) and `pymdownx.inlinehilite` for syntax highlighting in code blocks
- Fix `toc.permalink` from empty string to `true` for standard permalink behavior
- Add `mkdocs-minify-plugin` to minify HTML/JS/CSS output for faster page loads
- Move `search` plugin before `glightbox` for correct plugin load order
- Enable `--strict` mode in both CI build and deploy workflows to catch warnings as errors
- Add `site/` to `.gitignore`

## Test plan

- [x] Local `mkdocs build --strict` passes
- N/A CI build workflow passes on PR