### PR TITLE
docs: document Starr backup corruption check credentials

### DIFF
--- a/docs/pages/client/afterInstall.md
+++ b/docs/pages/client/afterInstall.md
@@ -196,9 +196,46 @@ You may optionally add Services, HTTP and Debug log files. These are not strictl
 1. On the Starr Apps pages, configure your apps.
     1. We recommend adding them all. If you have all the starr apps, add them all.
     1. All you need is a URL and an API key.
-    1. If you turn on database backup checks (on the website), a username and password is also required.
+    1. If you turn on database backup checks, a username and password is also required. See [Backup Corruption Checks](#backup-corruption-checks) below.
 1. Add all your download apps too. And Plex, and add Tautulli if you use it.
     Find these on their respective pages: *Download Apps* and *Media Apps*.
+
+### Backup Corruption Checks
+
+The client can monitor the scheduled database backups produced by your Starr apps
+(Lidarr, Prowlarr, Radarr, Readarr, Sonarr) for corruption and unexpected size loss.
+Enable it per app with the **Database Corrupt** trigger. The check runs on a cron,
+every 5 hours by default (with a small random offset so all apps don't fire at once).
+
+To inspect a backup, the client downloads the backup `.zip` from the app's **web UI**
+(e.g. `/backup/scheduled/*.zip`) — not from the API. When the app has authentication
+enabled, that download requires a logged-in session, so an **API key alone is not
+enough**: you must also provide the app's login `username` and `password`.
+
+!!! warning "authenticating as user \"\" failed"
+    If the username and password are missing when authentication is enabled, the
+    corruption check fails with:
+
+    ```text
+    authenticating as user "" failed: you may need to set a username and password to download backup files
+    ```
+
+Set the credentials either way:
+
+- **Client WebUI** — on the *Starr Apps* page, edit the app and fill in the Username
+  and Password fields alongside the URL and API key.
+- **Config file** — add `username` and `password` to the app's block in the client
+  config (`notifiarr.conf`):
+
+    ```yaml
+    radarr:
+      - url: "http://localhost:7878"
+        apiKey: "your-api-key"
+        username: "your-web-ui-username"
+        password: "your-web-ui-password"
+    ```
+
+    The same keys apply to the `sonarr`, `lidarr`, `readarr`, and `prowlarr` blocks.
 
 ### Health Checks
 

--- a/docs/pages/faq/faq.md
+++ b/docs/pages/faq/faq.md
@@ -53,6 +53,12 @@ ping origin-proxy.notifiarr.com
 
 - If you want the notifications to stop coming for a specific item, click the `Acknowledge` link in the notification. This is useful if something has a low amount of peers for example so it could take some time to complete it.
 
+## Q. Why do I get "you may need to set a username and password to download backup files"?
+
+- The **Database Corrupt** check downloads backup `.zip` files from the Starr app's web UI, which requires a logged-in session when the app has authentication enabled. An API key alone is not enough.
+
+- Add the app's web UI `username` and `password` in the client's WebUI on the *Starr Apps* page (or in the config file). See [Backup Corruption Checks](../client/afterInstall.md#backup-corruption-checks).
+
 ## Q. How do I test/troubleshoot Plex?
 
 ### Locating the Plex Token

--- a/docs/pages/integrations/radarr.md
+++ b/docs/pages/integrations/radarr.md
@@ -27,6 +27,11 @@
 - `Updates` - Receive a notification when the application updates
 - `Database Backup` - Receive a notification when a backup occurs
 - `Database Corrupt` - Monitor backups for corruption and size loss
+
+!!! note "Database Corrupt requires web UI credentials"
+    The corruption check downloads backup files from Radarr's web UI, so it needs a
+    `username` and `password` in addition to the API key when Radarr has authentication
+    enabled. See [Backup Corruption Checks](../client/afterInstall.md#backup-corruption-checks).
 - `Failed` - Custom notification type based on previous grabs. If the system detects a grab for the same media with the same quality or better before the previous one was imported then it will set the previous one as failed
 - `Health Check` - Receive a notification when the application reports an issue
 - `Health Restored` - Receive a notification when a health issue is resolved

--- a/docs/pages/integrations/sonarr.md
+++ b/docs/pages/integrations/sonarr.md
@@ -22,6 +22,11 @@
 - `Updates` - Receive a notification when the application updates
 - `Database Backup` - Receive a notification when a backup occurs
 - `Database Corrupt` - Monitor backups for corruption and size loss
+
+!!! note "Database Corrupt requires web UI credentials"
+    The corruption check downloads backup files from Sonarr's web UI, so it needs a
+    `username` and `password` in addition to the API key when Sonarr has authentication
+    enabled. See [Backup Corruption Checks](../client/afterInstall.md#backup-corruption-checks).
 - `Failed` - Custom notification type based on previous grabs. If the system detects a grab for the same media with the same quality or better before the previous one was imported then it will set the previous one as failed
 - `Health Check` - Receive a notification when the application reports an issue
 - `Health Restored` - Receive a notification when a health issue is resolved


### PR DESCRIPTION
Closes #42.

The `Database Corrupt` trigger downloads scheduled backup `.zip` files from the Starr app's **web UI** (`/backup/scheduled/*.zip`), not the API. When the app has authentication enabled this needs a login `username`/`password` in addition to the API key, otherwise the check fails with:

```text
authenticating as user "" failed: you may need to set a username and password to download backup files
```

## Changes

- **client/afterInstall.md** — new *Backup Corruption Checks* section: what it does, the ~5h cron, web-UI download → Forms auth, the exact error, and where to set credentials (client WebUI *Starr Apps* page or the config file).
- **integrations/radarr.md** / **integrations/sonarr.md** — note under the `Database Corrupt` trigger linking to the section.
- **faq/faq.md** — Q&A keyed on the error string.

## Verified against client source

- `pkg/triggers/backups/config.go`: `checkInterval = 5 * time.Hour` (+ up to 60min jitter).
- `pkg/triggers/backups/corruption.go`: `Get()` → on 401 `Login()` → retry; exact error string above.
- `golift.io/starr` config keys `username` / `password`.

`mkdocs build --strict` passes; all new anchor links resolve.