### PR TITLE
docs: fix backup-check config example to TOML

### DIFF
--- a/docs/pages/client/afterInstall.md
+++ b/docs/pages/client/afterInstall.md
@@ -227,15 +227,16 @@ Set the credentials either way:
 - **Config file** — add `username` and `password` to the app's block in the client
   config (`notifiarr.conf`):
 
-    ```yaml
-    radarr:
-      - url: "http://localhost:7878"
-        apiKey: "your-api-key"
-        username: "your-web-ui-username"
-        password: "your-web-ui-password"
+    ```toml
+    [[radarr]]
+      name     = "Radarr"
+      url      = "http://127.0.0.1:7878"
+      api_key  = "your-api-key"
+      username = "your-web-ui-username"
+      password = "your-web-ui-password"
     ```
 
-    The same keys apply to the `sonarr`, `lidarr`, `readarr`, and `prowlarr` blocks.
+    The same keys apply to the `[[sonarr]]`, `[[lidarr]]`, `[[readarr]]`, and `[[prowlarr]]` blocks.
 
 ### Health Checks
 


### PR DESCRIPTION
Follow-up to #43. The backup-corruption config snippet was written in **YAML** but labeled `notifiarr.conf` — which is a **TOML** file — and used camelCase `apiKey`. Copy-pasting it would not work.

Converts it to the real `notifiarr.conf` format, matching [`examples/notifiarr.conf.example`](https://github.com/Notifiarr/notifiarr/blob/main/examples/notifiarr.conf.example):

```toml
[[radarr]]
  name     = "Radarr"
  url      = "http://127.0.0.1:7878"
  api_key  = "your-api-key"
  username = "your-web-ui-username"
  password = "your-web-ui-password"
```

Also updates the "same keys apply" line to reference the `[[sonarr]]` / `[[lidarr]]` / `[[readarr]]` / `[[prowlarr]]` tables. `mkdocs build --strict` passes.