### PR TITLE
ci: dedupe runs, simplify pre-commit, DRY build/deploy

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -1,0 +1,39 @@
+# Reusable MkDocs build — called by build.yml (PR validation) and deploy.yml (Pages publish)
+name: Build (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      upload-site:
+        description: "Upload built ./site as the 'site' artifact"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+      - run: python3 -m pip install --upgrade pip
+      - id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v6
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - run: |
+          python3 -m pip install -r requirements.txt
+          mkdocs build --strict
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload-site }}
+        with:
+          name: site
+          path: ./site

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,7 @@
+# Validate MkDocs builds cleanly on every PR to main
 name: Build
 
 on:
-  push:
-    branches-ignore:
-      - main
   pull_request:
     branches:
       - main
@@ -11,26 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.14"
-      - run: python3 -m pip install --upgrade pip
-      - id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v6
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - run: |
-          python3 -m pip install -r requirements.txt
-          mkdocs build --strict
+    uses: ./.github/workflows/_build.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,4 @@
+# Build and publish MkDocs site to GitHub Pages on every push to main
 name: GitHub Pages
 
 on:
@@ -5,47 +6,33 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  build:
+    uses: ./.github/workflows/_build.yml
+    with:
+      upload-site: true
+
   deploy:
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - name: Clone repository
         uses: actions/checkout@v7
 
-      - name: Setup Python environment
-        uses: actions/setup-python@v7
+      - name: Download built site
+        uses: actions/download-artifact@v4
         with:
-          python-version: "3.14"
-
-      - name: Upgrade pip
-        run: python3 -m pip install --upgrade pip
-
-      - name: Get pip cache directory
-        id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: python3 -m pip install -r ./requirements.txt
-
-      - name: Build Docs
-        run: mkdocs build --strict
+          name: site
+          path: ./site
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
-        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,11 +1,9 @@
+# Lint all files with pre-commit on every PR to main
 name: Pre-commit
 
 on:
   pull_request:
     branches:
-      - main
-  push:
-    branches-ignore:
       - main
 
 permissions:
@@ -20,38 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with:
-          # Need full history so pre-commit can diff against the PR base.
-          fetch-depth: 0
       - uses: actions/setup-python@v7
         with:
           python-version: "3.14"
       - uses: actions/setup-node@v7
         with:
           node-version: "24"
-      # Only check files changed in the PR / push. Adding pre-commit to a
-      # repo with existing content shouldn't fail on legacy violations —
-      # only new/modified files get linted. Maintainers can clean up the
-      # backlog with `pre-commit run --all-files` in follow-up sweeps.
-      - name: Resolve change range
-        id: range
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "from=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
-            echo "to=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-          else
-            from="${{ github.event.before }}"
-            # First push of a new branch reports before=0000... — fall back to HEAD~1
-            if [ "$from" = "0000000000000000000000000000000000000000" ] || [ -z "$from" ]; then
-              from=$(git rev-parse HEAD~1 2>/dev/null || echo "")
-            fi
-            # If branch has only one commit, lint just the HEAD commit
-            if [ -z "$from" ]; then
-              from="${{ github.sha }}"
-            fi
-            echo "from=$from" >> "$GITHUB_OUTPUT"
-            echo "to=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          fi
       - uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --from-ref ${{ steps.range.outputs.from }} --to-ref ${{ steps.range.outputs.to }}


### PR DESCRIPTION
Four CI improvements in one PR.

1. **No more double CI runs** — `build.yml` and `precommit.yml` triggered on both `push` and `pull_request`, so a branch push + PR ran each twice. Now `pull_request: [main]` only. (Fork PRs were already single-run.)
2. **Simplify `precommit.yml`** — the repo backlog is clean, so the ~25-line "resolve change range" shell (needed only to skip legacy violations) is removed; `pre-commit/action` runs `--all-files` by default. More robust (catches regressions in untouched files).
3. **DRY build/deploy** — extracted the shared build into a reusable `_build.yml` (`workflow_call`, optional `upload-site`). `build.yml` calls it for PR validation; `deploy.yml` calls it (uploading the `site` artifact) then a `deploy` job downloads and publishes.
4. **Remove redundant `if`** — dropped the always-true `if: github.ref == 'refs/heads/main'` on the deploy step.

**Deploy safety:** the Pages publish is byte-for-byte preserved — `checkout` (git context for peaceiris) → `download-artifact` (the built `./site`) → unchanged `peaceiris/actions-gh-pages@v4` with the same `cname: notifiarr.wiki`, token, `publish_dir`, and bot identity. actionlint passes on all four files.

> Note: the Build + Pre-commit jobs are exercised by this PR's CI, but the new `deploy.yml` artifact hand-off only runs on push to `main` — worth a glance at the first Pages deploy after merge.