### PR TITLE
docs: cover discordApp spam trap, dockwatch intrusion trigger, trash keywords

### DIFF
--- a/docs/pages/integrations/discordApp.md
+++ b/docs/pages/integrations/discordApp.md
@@ -138,7 +138,7 @@ Automatically moderate spam/compromised accounts posting in designated "trap" ch
 
 - Configure one or more trap channels — any message posted in a trap channel triggers moderation immediately
 - Exclude specific roles from moderation (excluded roles still produce an ignored mod-log notice instead)
-- `Kick if member longer than (days)` - Members newer than this threshold are **banned**; members older than it are **kicked** (temporary ban, messages deleted after 15 minutes, then unbanned). Default is 30 days.
+- `Kick if member longer than (days)` - Members newer than this threshold are **banned**; members older than it are **kicked** (a "soft ban" — Discord bans the member with a 15-minute message-delete window, purging their messages from **every channel** they posted in during that window, then immediately removes the ban). Default is 30 days.
 - Notification color customization
 - Requires the bot to have the **Ban Members** and **Manage Messages** permissions, and the bot's role must be **higher than** the target user's highest role
 - Trap channel(s) must allow **@everyone** (or the roles you expect spammers to use) to **send messages**, otherwise the trap will not trigger

--- a/docs/pages/integrations/discordApp.md
+++ b/docs/pages/integrations/discordApp.md
@@ -132,6 +132,17 @@ Automatically archive stale threads.
 - Select which channels to monitor
 - Restrict to specific roles
 
+### Spam Trap
+
+Automatically moderate spam/compromised accounts posting in designated "trap" channels.
+
+- Configure one or more trap channels — any message posted in a trap channel triggers moderation immediately
+- Exclude specific roles from moderation (excluded roles still produce an ignored mod-log notice instead)
+- `Kick if member longer than (days)` - Members newer than this threshold are **banned**; members older than it are **kicked** (temporary ban, messages deleted after 15 minutes, then unbanned). Default is 30 days.
+- Notification color customization
+- Requires the bot to have the **Ban Members** and **Manage Messages** permissions, and the bot's role must be **higher than** the target user's highest role
+- Trap channel(s) must allow **@everyone** (or the roles you expect spammers to use) to **send messages**, otherwise the trap will not trigger
+
 ### Ban Sync
 
 Participate in ban synchronization across Notifiarr-connected Discord servers.

--- a/docs/pages/integrations/dockwatch.md
+++ b/docs/pages/integrations/dockwatch.md
@@ -20,6 +20,10 @@
 
 6. `Security` - Trigger a notification when DockWatch detects a security issue with a container.
 
+7. `Intrusion` - Trigger a notification when DockWatch itself detects a security event on its own UI/API, such as an invalid login, login lockout, direct access attempt, invalid API key, unauthorized request, invalid CSRF token, or a WebSocket connection with missing params or an invalid token.
+    - Notification field: `IP map` - When enabled, includes a generated map image showing the country/state/city/ISP for the offending IP (skipped for private/local IPs).
+    - Depending on the event type, the notification may also include the request method, username, container, endpoint, API key, token, referrer, and user agent.
+
 ## Instructions
 
 ![instructions.png](../../assets/screenshots/integrations/Dockwatch/instructions.png)
@@ -51,6 +55,7 @@ Here is the setup on dockwatch's end.
 
 1. `Customize` - Under the customize tab you can change the color of your notification for each available trigger.
 2. `Full image names` - Show the full image name instead of truncating with ellipsis.
+3. `IP map` - Under the Intrusion trigger, include a map image with the offending IP's geolocation in the notification.
 
 ### Notification Examples
 

--- a/docs/pages/integrations/trash.md
+++ b/docs/pages/integrations/trash.md
@@ -163,6 +163,15 @@ This section has "one off" actions that can be applied to an instance but really
 
 ![tools-tab.png](../../assets/screenshots/integrations/trash/tools-tab.png)
 
+#### Keywords
+
+The Tools tab also has a Keywords table for Discord-triggered format/profile search:
+
+- `!format {query}` - Fuzzy-searches your synced formats and replies with the closest matches
+- `!profile {query}` - Fuzzy-searches your synced profiles and replies with the closest matches
+- Each keyword can be independently enabled, restricted to specific channels (or any channel), and restricted to specific roles (or any role)
+- Optional: Disable the random "no permission" response and use a simple message instead
+
 ### <span style="color:orange;">Guides</span>
 
 !!! info


### PR DESCRIPTION
## Summary

Updates three integration pages to cover website-source features added since the last comprehensive wiki review (base commit `d807479a`, 2026-06-07):

- **Discord App** — new Spam Trap feature (trap channels, role exclusions, kick/ban threshold, permission requirements)
- **DockWatch** — new Intrusion trigger (invalid login, lockout, direct access, invalid API key/CSRF, WebSocket auth failures) and the IP map setting
- **TRaSH** — new `!format`/`!profile` Discord keyword search, with per-channel/per-role restrictions

Bug-fix-only changes in this window (bazarr season/episode formatting, seerr ping array handling, mdblist type coercion) were left undocumented since they don't change user-facing behavior or config.

## Test plan

- [x] `pre-commit run` (markdownlint, cspell, trailing-whitespace, etc.) passes on all changed files
- [ ] Wiki maintainer spot-check against the live website UI for wording/screenshots